### PR TITLE
[Lendo] 6주차 QueryDSL 과제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,15 @@ repositories {
 }
 
 dependencies {
+    // --- Jakarta Validation ---
+    implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+    implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
+
+    // --- QueryDSL ---
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/spring_boot_a/api/review/MyReviewController.java
+++ b/src/main/java/com/example/spring_boot_a/api/review/MyReviewController.java
@@ -1,0 +1,26 @@
+package com.example.spring_boot_a.api.review;
+
+import com.example.spring_boot_a.api.review.dto.MyReviewItemDto;
+import com.example.spring_boot_a.domain.service.MyReviewQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MyReviewController {
+
+    private final MyReviewQueryService service;
+
+    @GetMapping("/users/{userId}/my-reviews")
+    public Page<MyReviewItemDto> myReviews(
+            @PathVariable Long userId,
+            @RequestParam(required = false) String storeName,
+            @RequestParam(required = false) Integer starBucket,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return service.query(userId, storeName, starBucket, page, size);
+    }
+}

--- a/src/main/java/com/example/spring_boot_a/api/review/ReviewController.java
+++ b/src/main/java/com/example/spring_boot_a/api/review/ReviewController.java
@@ -1,0 +1,53 @@
+package com.example.spring_boot_a.api.review;
+
+import com.example.spring_boot_a.api.review.dto.*;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+    public ReviewController(ReviewService reviewService) { this.reviewService = reviewService; }
+
+
+    @PostMapping("/stores/{storeId}/reviews")
+    public Long createReview(
+            @PathVariable Long storeId,
+            @RequestParam Long userId,              // 실제로는 인증에서 추출
+            @RequestBody @Valid ReviewCreateRequest request
+    ) {
+        return reviewService.create(userId, storeId, request);
+    }
+
+
+    @GetMapping("/stores/{storeId}/reviews")
+    public Page<ReviewResponse> getStoreReviews(
+            @PathVariable Long storeId,
+            @RequestParam(required = false) Integer starBucket, // 5 or 4 or 3 or 2 or 1
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return reviewService.getStoreReviews(storeId, starBucket, pageable);
+    }
+
+
+    @GetMapping("/users/{userId}/reviews")
+    public Page<ReviewResponse> getMyReviews(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return reviewService.getMyReviews(userId, pageable);
+    }
+
+
+    @GetMapping("/stores/{storeId}/reviews/star-summary")
+    public StarSummaryResponse getStarSummary(@PathVariable Long storeId) {
+        return reviewService.getStarSummary(storeId);
+    }
+}

--- a/src/main/java/com/example/spring_boot_a/api/review/ReviewService.java
+++ b/src/main/java/com/example/spring_boot_a/api/review/ReviewService.java
@@ -1,0 +1,118 @@
+package com.example.spring_boot_a.api.review;
+
+import com.example.spring_boot_a.api.review.dto.*;
+import com.example.spring_boot_a.domain.entity.*;
+import com.example.spring_boot_a.domain.repository.*;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+    private final ReviewPhotoRepository photoRepository;
+    private final ReplyRepository replyRepository;
+    private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
+
+    public ReviewService(ReviewRepository reviewRepository,
+                         ReviewPhotoRepository photoRepository,
+                         ReplyRepository replyRepository,
+                         UserRepository userRepository,
+                         StoreRepository storeRepository) {
+        this.reviewRepository = reviewRepository;
+        this.photoRepository = photoRepository;
+        this.replyRepository = replyRepository;
+        this.userRepository = userRepository;
+        this.storeRepository = storeRepository;
+    }
+
+    @Transactional
+    public Long create(Long userId, Long storeId, ReviewCreateRequest req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("user not found"));
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new EntityNotFoundException("store not found"));
+
+        Review r = new Review();
+        r.setUser(user);
+        r.setStore(store);
+        r.setStar(req.star());
+        r.setContent(req.content());
+
+        Review saved = reviewRepository.save(r);
+
+        if (req.photoUrls() != null && !req.photoUrls().isEmpty()) {
+            for (String url : req.photoUrls()) {
+                ReviewPhoto p = new ReviewPhoto();
+                p.setReview(saved);
+                p.setPhotoUrl(url);
+                photoRepository.save(p);
+            }
+        }
+        return saved.getReviewId();
+    }
+
+    public Page<ReviewResponse> getStoreReviews(Long storeId, Integer starBucket, Pageable pageable) {
+        Page<Review> page;
+        if (starBucket == null) {
+            page = reviewRepository.findByStore_StoreIdOrderByCreatedAtDesc(storeId, pageable);
+        } else if (starBucket == 5) {
+            page = reviewRepository.findByStore_StoreIdAndStarEqualsOrderByCreatedAtDesc(
+                    storeId, 5.0f, pageable);
+        } else {
+            float min = starBucket.floatValue();
+            float max = starBucket + 1.0f;
+            page = reviewRepository
+                    .findByStore_StoreIdAndStarGreaterThanEqualAndStarLessThanOrderByCreatedAtDesc(
+                            storeId, min, max, pageable);
+        }
+        return enrich(page);
+    }
+
+    public Page<ReviewResponse> getMyReviews(Long userId, Pageable pageable) {
+        Page<Review> page = reviewRepository.findByUser_UserIdOrderByCreatedAtDesc(userId, pageable);
+        return enrich(page);
+    }
+
+    public StarSummaryResponse getStarSummary(Long storeId) {
+        Object[] arr = reviewRepository.countBucketsByStore(storeId);
+        long s5 = ((Number) arr[0]).longValue();
+        long s4 = ((Number) arr[1]).longValue();
+        long s3 = ((Number) arr[2]).longValue();
+        long s2 = ((Number) arr[3]).longValue();
+        long s1 = ((Number) arr[4]).longValue();
+        double avg = reviewRepository.findAvgStarByStore(storeId);
+        return new StarSummaryResponse(s5, s4, s3, s2, s1, avg);
+    }
+
+    private Page<ReviewResponse> enrich(Page<Review> page) {
+        List<Long> ids = page.stream().map(Review::getReviewId).toList();
+
+        Map<Long, List<String>> photosByReview = photoRepository.findByReview_ReviewIdIn(ids).stream()
+                .collect(Collectors.groupingBy(p -> p.getReview().getReviewId(),
+                        Collectors.mapping(ReviewPhoto::getPhotoUrl, Collectors.toList())));
+
+        Map<Long, List<String>> repliesByReview = replyRepository.findByReview_ReviewIdIn(ids).stream()
+                .collect(Collectors.groupingBy(r -> r.getReview().getReviewId(),
+                        Collectors.mapping(Reply::getContent, Collectors.toList())));
+
+        List<ReviewResponse> mapped = page.stream().map(r ->
+                new ReviewResponse(
+                        r.getReviewId(),
+                        r.getUser().getName(),
+                        r.getStar(),
+                        r.getContent(),
+                        r.getCreatedAt(),
+                        photosByReview.getOrDefault(r.getReviewId(), List.of()),
+                        repliesByReview.getOrDefault(r.getReviewId(), List.of())
+                )).toList();
+
+        return new PageImpl<>(mapped, page.getPageable(), page.getTotalElements());
+    }
+}

--- a/src/main/java/com/example/spring_boot_a/api/review/dto/MyReviewItemDto.java
+++ b/src/main/java/com/example/spring_boot_a/api/review/dto/MyReviewItemDto.java
@@ -1,0 +1,14 @@
+package com.example.spring_boot_a.api.review.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record MyReviewItemDto(
+        Long reviewId,
+        String storeName,
+        Float star,
+        String content,
+        Instant createdAt,
+        List<String> photoUrls,
+        String reply
+) {}

--- a/src/main/java/com/example/spring_boot_a/api/review/dto/ReviewCreateRequest.java
+++ b/src/main/java/com/example/spring_boot_a/api/review/dto/ReviewCreateRequest.java
@@ -1,0 +1,10 @@
+package com.example.spring_boot_a.api.review.dto;
+
+import jakarta.validation.constraints.*;
+import java.util.List;
+
+public record ReviewCreateRequest(
+        @NotNull Float star,
+        @NotBlank String content,
+        List<@Size(max = 500) String> photoUrls
+) {}

--- a/src/main/java/com/example/spring_boot_a/api/review/dto/ReviewResponse.java
+++ b/src/main/java/com/example/spring_boot_a/api/review/dto/ReviewResponse.java
@@ -1,0 +1,14 @@
+package com.example.spring_boot_a.api.review.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record ReviewResponse(
+        Long reviewId,
+        String userName,
+        Float star,
+        String content,
+        Instant createdAt,
+        List<String> photos,
+        List<String> replies
+) {}

--- a/src/main/java/com/example/spring_boot_a/api/review/dto/StarSummaryResponse.java
+++ b/src/main/java/com/example/spring_boot_a/api/review/dto/StarSummaryResponse.java
@@ -1,0 +1,10 @@
+package com.example.spring_boot_a.api.review.dto;
+
+public record StarSummaryResponse(
+        long s5,
+        long s4x,
+        long s3x,
+        long s2x,
+        long s1x,
+        double avg
+) {}

--- a/src/main/java/com/example/spring_boot_a/config/QuerydslConfig.java
+++ b/src/main/java/com/example/spring_boot_a/config/QuerydslConfig.java
@@ -1,0 +1,14 @@
+package com.example.spring_boot_a.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/example/spring_boot_a/domain/repository/ReplyRepository.java
+++ b/src/main/java/com/example/spring_boot_a/domain/repository/ReplyRepository.java
@@ -1,0 +1,11 @@
+package com.example.spring_boot_a.domain.repository;
+
+import com.example.spring_boot_a.domain.entity.Reply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface ReplyRepository extends JpaRepository<Reply, Long> {
+    List<Reply> findByReview_ReviewIdIn(Collection<Long> reviewIds);
+}

--- a/src/main/java/com/example/spring_boot_a/domain/repository/ReviewPhotoRepository.java
+++ b/src/main/java/com/example/spring_boot_a/domain/repository/ReviewPhotoRepository.java
@@ -1,0 +1,11 @@
+package com.example.spring_boot_a.domain.repository;
+
+import com.example.spring_boot_a.domain.entity.ReviewPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface ReviewPhotoRepository extends JpaRepository<ReviewPhoto, Long> {
+    List<ReviewPhoto> findByReview_ReviewIdIn(Collection<Long> reviewIds);
+}

--- a/src/main/java/com/example/spring_boot_a/domain/repository/ReviewQueryRepository.java
+++ b/src/main/java/com/example/spring_boot_a/domain/repository/ReviewQueryRepository.java
@@ -1,0 +1,14 @@
+package com.example.spring_boot_a.domain.repository;
+
+import com.example.spring_boot_a.api.review.dto.MyReviewItemDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReviewQueryRepository {
+    Page<MyReviewItemDto> findMyReviews(
+            Long userId,
+            String storeName,
+            Integer starBucket,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/example/spring_boot_a/domain/repository/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/com/example/spring_boot_a/domain/repository/ReviewQueryRepositoryImpl.java
@@ -1,0 +1,135 @@
+package com.example.spring_boot_a.domain.repository;
+
+import com.example.spring_boot_a.api.review.dto.MyReviewItemDto;
+import com.example.spring_boot_a.domain.entity.QReply;
+import com.example.spring_boot_a.domain.entity.QReview;
+import com.example.spring_boot_a.domain.entity.QReviewPhoto;
+import com.example.spring_boot_a.domain.entity.QStore;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
+
+    private final JPAQueryFactory query;
+
+    private static final QReview r = QReview.review;
+    private static final QStore s = QStore.store;
+    private static final QReviewPhoto p = QReviewPhoto.reviewPhoto;
+    private static final QReply rp = QReply.reply;
+
+    @Override
+    public Page<MyReviewItemDto> findMyReviews(Long userId, String storeName, Integer starBucket, Pageable pageable) {
+
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(r.user.userId.eq(userId));
+
+        if (storeName != null && !storeName.isBlank()) {
+
+            where.and(r.store.name.eq(storeName));
+        }
+        if (starBucket != null) {
+            if (starBucket == 5) {
+                where.and(r.star.eq(5.0f));
+            } else {
+                float min = starBucket.floatValue();
+                float max = min + 1.0f;
+                where.and(r.star.goe(min).and(r.star.lt(max)));
+            }
+        }
+
+
+        List<Long> reviewIds = query
+                .select(r.reviewId)
+                .from(r)
+                .join(r.store, s)
+                .where(where)
+                .orderBy(r.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        if (reviewIds.isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, 0);
+        }
+
+
+        Map<Long, TupleLite> base = query
+                .select(r.reviewId, s.name, r.star, r.content, r.createdAt)
+                .from(r)
+                .join(r.store, s)
+                .where(r.reviewId.in(reviewIds))
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        t -> t.get(r.reviewId),
+                        t -> new TupleLite(
+                                t.get(s.name),
+                                t.get(r.star),
+                                t.get(r.content),
+                                t.get(r.createdAt))
+                ));
+
+
+        Map<Long, List<String>> photosByReview = query
+                .select(p.review.reviewId, p.photoUrl)
+                .from(p)
+                .where(p.review.reviewId.in(reviewIds))
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(
+                        t -> t.get(p.review.reviewId),
+                        Collectors.mapping(t -> t.get(p.photoUrl), Collectors.toList())
+                ));
+
+
+        Map<Long, String> replyByReview = query
+                .select(rp.review.reviewId, rp.content, rp.replyId)
+                .from(rp)
+                .where(rp.review.reviewId.in(reviewIds))
+                .orderBy(rp.review.reviewId.asc(), rp.replyId.desc()) // 같은 리뷰 내 최신
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        t -> t.get(rp.review.reviewId),
+                        t -> t.get(rp.content),
+                        (oldVal, newVal) -> oldVal // 첫 번째(최신) 유지
+                ));
+
+
+        List<MyReviewItemDto> content = reviewIds.stream()
+                .map(id -> {
+                    TupleLite b = base.get(id);
+                    return new MyReviewItemDto(
+                            id,
+                            b.storeName,
+                            b.star,
+                            b.content,
+                            b.createdAt,
+                            photosByReview.getOrDefault(id, List.of()),
+                            replyByReview.get(id)
+                    );
+                })
+                .toList();
+
+
+        Long total = query.select(r.count())
+                .from(r)
+                .join(r.store, s)
+                .where(where)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0 : total);
+    }
+
+    // 내부 전용 최소 튜플
+    private record TupleLite(String storeName, Float star, String content, java.time.Instant createdAt) {}
+}

--- a/src/main/java/com/example/spring_boot_a/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/example/spring_boot_a/domain/repository/ReviewRepository.java
@@ -1,0 +1,40 @@
+package com.example.spring_boot_a.domain.repository;
+
+import com.example.spring_boot_a.domain.entity.Review;
+import org.springframework.data.domain.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+
+    Page<Review> findByStore_StoreIdOrderByCreatedAtDesc(Long storeId, Pageable pageable);
+
+
+    Page<Review> findByStore_StoreIdAndStarGreaterThanEqualAndStarLessThanOrderByCreatedAtDesc(
+            Long storeId, Float min, Float max, Pageable pageable);
+
+    Page<Review> findByStore_StoreIdAndStarEqualsOrderByCreatedAtDesc(
+            Long storeId, Float star, Pageable pageable);
+
+
+    Page<Review> findByUser_UserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+
+    @Query("select coalesce(avg(r.star),0) from Review r where r.store.storeId = :storeId")
+    double findAvgStarByStore(@Param("storeId") Long storeId);
+
+
+    @Query("""
+           select 
+             sum(case when r.star = 5 then 1 else 0 end),
+             sum(case when r.star >= 4 and r.star < 5 then 1 else 0 end),
+             sum(case when r.star >= 3 and r.star < 4 then 1 else 0 end),
+             sum(case when r.star >= 2 and r.star < 3 then 1 else 0 end),
+             sum(case when r.star >= 1 and r.star < 2 then 1 else 0 end)
+           from Review r
+           where r.store.storeId = :storeId
+           """)
+    Object[] countBucketsByStore(@Param("storeId") Long storeId);
+
+}

--- a/src/main/java/com/example/spring_boot_a/domain/repository/StoreRepository.java
+++ b/src/main/java/com/example/spring_boot_a/domain/repository/StoreRepository.java
@@ -1,0 +1,7 @@
+package com.example.spring_boot_a.domain.repository;
+
+import com.example.spring_boot_a.domain.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store,Long> {
+}

--- a/src/main/java/com/example/spring_boot_a/domain/repository/UserMissionRepository.java
+++ b/src/main/java/com/example/spring_boot_a/domain/repository/UserMissionRepository.java
@@ -1,0 +1,23 @@
+package com.example.spring_boot_a.domain.repository;
+
+import com.example.spring_boot_a.domain.entity.UserMission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface UserMissionRepository extends JpaRepository<UserMission, Long> {
+    @Query("""
+      select um from UserMission um
+      where um.user.userId = :userId
+        and um.isComplete = true
+        and not exists (
+          select 1 from Review r
+          where r.user.userId = um.user.userId
+            and r.store.storeId = um.mission.store.storeId
+        )
+      order by um.userMissionId desc
+    """)
+    List<UserMission> findCompletesWithoutReview(@Param("userId") Long userId);
+}

--- a/src/main/java/com/example/spring_boot_a/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/spring_boot_a/domain/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.example.spring_boot_a.domain.repository;
+
+import com.example.spring_boot_a.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/spring_boot_a/domain/service/MyReviewQueryService.java
+++ b/src/main/java/com/example/spring_boot_a/domain/service/MyReviewQueryService.java
@@ -1,0 +1,19 @@
+package com.example.spring_boot_a.domain.service;
+
+import com.example.spring_boot_a.api.review.dto.MyReviewItemDto;
+import com.example.spring_boot_a.domain.repository.ReviewQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MyReviewQueryService {
+    private final ReviewQueryRepository reviewQueryRepository;
+
+    public Page<MyReviewItemDto> query(Long userId, String storeName, Integer starBucket, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return reviewQueryRepository.findMyReviews(userId, storeName, starBucket, pageable);
+
+    }
+}


### PR DESCRIPTION
## ✅ 워크북 체크리스트

- [x] 모든 핵심 키워드 정리를 마쳤나요?
- [x] 핵심 키워드에 대해 완벽히 이해하셨나요?
- [x] 이론 학습 이후 직접 실습을 해보는 시간을 가졌나요?
- [x] 미션을 수행하셨나요?
- [x] 미션을 기록하셨나요?
      <br>

## ✅ 컨벤션 체크리스트

- [ ] 디렉토리 구조 컨벤션을 잘 지켰나요?
- [ ] pr 제목을 컨벤션에 맞게 작성하였나요?
- [ ] pr에 해당되는 이슈를 연결하였나요?
- [x] 적절한 라벨을 설정하였나요?
- [x] 스터디원들에게 code review를 요청하기 위해 reviewer를 등록하였나요?
- [x] 닉네임/main 브랜치의 최신 상태를 반영하고 있는지 확인했나요?
      <br>

## 📌 주안점

이번 과제를 하면서 깃헙이랑 연동되어있다는걸 잊고 커밋을 한번도 안날려서 이런 참사가 일어났습니다... 설명을 구체적으로 적어보겠습니다

1. build.gradle: 검증 + QueryDSL 세팅
2. Controller 레이어: REST API 엔드포인트들
- ReviewController

1. 리뷰 작성
2. 특정 가게 리뷰 목록 + 별점 버킷 필터
3. 특정 유저의 리뷰 목록
4. 가게 별점 요약
이들을 DTO를 통해서 요청을 받고 각각 @Valid를 통해 요구사항에 대해서 검증했고 결과값을 페이징 기능을 추가해 리턴했습니다

- MyReviewController
- **나의 리뷰 목록 + 필터 기능 + 사진 + 가게 이름 + 최신 사장님 답글 1개**를 한 번에 조회
- `storeName`, `starBucket` 필터를 지원
- 내부적으로는 **QueryDSL 커스텀 리포지토리** 사용 (`ReviewQueryRepositoryImpl`)

서비스 로직에서는 
- ReviewService

1. 리뷰생성
2. 가게별 리뷰 조회 + 버킷 필터
3. 나의 리뷰 간단 조회
4. 별점 요약 조회
를 추가했습니다

Repository 레이어에서는 JPA + QueryDSL를 사용했습니다
JPA를 기본적으로 사용해 동적쿼리를 제외하고 복잡한 쿼리는 jpql을 통해 생성형 AI를 통해 코드를 짰습니다

동적쿼리는 QueryDsl을 사용했는데 

### 1. `QuerydslConfig` : JPAQueryFactory 빈 등록

```java
@Configuration
public class QuerydslConfig {
    @Bean
    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
        return new JPAQueryFactory(em);
    }
}

```

- 스프링 컨테이너에 `JPAQueryFactory` 빈을 올려서, 어디서든 의존성 주입해서 QueryDSL 사용 가능하게 함

### 2. 커스텀 리포지토리 인터페이스

```java
public interface ReviewQueryRepository {
    Page<MyReviewItemDto> findMyReviews(
            Long userId,
            String storeName,
            Integer starBucket,
            Pageable pageable
    );
}

```

- “나의 리뷰 + 필터 + 사진 + 최신 답글 1개” 전용 쿼리의 스펙 정의

### 3. `ReviewQueryRepositoryImpl`: QueryDSL로 구현


```java
@Repository
@RequiredArgsConstructor
public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {

    private final JPAQueryFactory query;

    private static final QReview r = QReview.review;
    private static final QStore s = QStore.store;
    private static final QReviewPhoto p = QReviewPhoto.reviewPhoto;
    private static final QReply rp = QReply.reply;

```

### where 조건 쌓기 

```java
BooleanBuilder where = new BooleanBuilder();
where.and(r.user.userId.eq(userId));

if (storeName != null && !storeName.isBlank()) {
    where.and(r.store.name.eq(storeName));
}
if (starBucket != null) {
    if (starBucket == 5) {
        where.and(r.star.eq(5.0f));
    } else {
        float min = starBucket.floatValue();
        float max = min + 1.0f;
        where.and(r.star.goe(min).and(r.star.lt(max)));
    }
}

```

- 사용자 ID는 필수
- 가게 이름, 별점 버킷은 있으면 &&로 붙이는 방식

###  페이징용 reviewId 목록 먼저 조회

```java
List<Long> reviewIds = query
        .select(r.reviewId)
        .from(r)
        .join(r.store, s)
        .where(where)
        .orderBy(r.createdAt.desc())
        .offset(pageable.getOffset())
        .limit(pageable.getPageSize())
        .fetch();

```

- 먼저 조건 + 페이징을 적용해서 **리뷰 PK id만** 뽑아옴
- 이걸 기준으로 나중에 관련 데이터들을 붙이는 패턴

###  기본 정보(base) 조회 후 Map으로 변환

```java
Map<Long, TupleLite> base = query
        .select(r.reviewId, s.name, r.star, r.content, r.createdAt)
        .from(r)
        .join(r.store, s)
        .where(r.reviewId.in(reviewIds))
        .fetch()
        .stream()
        .collect(Collectors.toMap(
                t -> t.get(r.reviewId),
                t -> new TupleLite(
                        t.get(s.name),
                        t.get(r.star),
                        t.get(r.content),
                        t.get(r.createdAt))
        ));

```

- reviewId → (가게 이름, 별점, 내용, 작성 시각) 구조로 매핑해두는 Map

###  사진 모으기

```java
Map<Long, List<String>> photosByReview = query
        .select(p.review.reviewId, p.photoUrl)
        .from(p)
        .where(p.review.reviewId.in(reviewIds))
        .fetch()
        .stream()
        .collect(Collectors.groupingBy(
                t -> t.get(p.review.reviewId),
                Collectors.mapping(t -> t.get(p.photoUrl), Collectors.toList())
        ));

```

- `reviewId` 기준으로 사진 URL들을 리스트로 그룹핑

###  최신 답글 1개 가져오기

```java
Map<Long, String> replyByReview = query
        .select(rp.review.reviewId, rp.content, rp.replyId)
        .from(rp)
        .where(rp.review.reviewId.in(reviewIds))
        .orderBy(rp.review.reviewId.asc(), rp.replyId.desc()) // 같은 리뷰 내 최신
        .fetch()
        .stream()
        .collect(Collectors.toMap(
                t -> t.get(rp.review.reviewId),
                t -> t.get(rp.content),
                (oldVal, newVal) -> oldVal // 첫 번째(최신) 유지
        ));

```

- 같은 리뷰 안에서는 `replyId desc`로 정렬했기 때문에 **첫 번째가 최신**
- `Collectors.toMap`에서 key충돌 시 `(oldVal, newVal) -> oldVal`로 설정 → 가장 앞(최신) 값만 유지

###  최종 DTO 리스트 만들기

```java
List<MyReviewItemDto> content = reviewIds.stream()
        .map(id -> {
            TupleLite b = base.get(id);
            return new MyReviewItemDto(
                    id,
                    b.storeName,
                    b.star,
                    b.content,
                    b.createdAt,
                    photosByReview.getOrDefault(id, List.of()),
                    replyByReview.get(id)
            );
        })
        .toList();

```

- **처음 뽑았던 reviewIds 순서 그대로** DTO를 만들어서 페이징 정렬을 유지

###  total 카운트 쿼리

```java
Long total = query.select(r.count())
        .from(r)
        .join(r.store, s)
        .where(where)
        .fetchOne();

return new PageImpl<>(content, pageable, total == null ? 0 : total);

```

- 같은 where 조건으로 count(*)를 날려서 전체 개수 조회
- `PageImpl`로 스프링 데이터 `Page` 객체 생성

를 생성하여 QueryDsl 학습인 만큼 신경을 써보았습니다.
